### PR TITLE
Bump version to 0.6.1 and update dash-mantine-components dependency 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cardcanvas"
-version = "0.6.0"
+version = "0.6.1"
 description = "Configurable dashboard with dash"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "dash>=3.0.0",
     "dash-iconify>=0.1.2",
-    "dash-mantine-components>=1.3.0",
+    "dash-mantine-components>=2.0.0",
     "dash-snap-grid>=0.3.1",
 ]
 authors = [


### PR DESCRIPTION
dash-mantine-component version pinned to >=2.0.0 since notification containers were introduced only in that version